### PR TITLE
Fix no id set for some fcc and bcc cases.

### DIFF
--- a/src/niggli.f90
+++ b/src/niggli.f90
@@ -657,6 +657,10 @@ CONTAINS
                 s_range = 10
                 O = reshape((/-1.464824_dp,0.464824_dp,1.907413_dp,-0.153209_dp,0.153209_dp, &
                      -2.907413_dp,1.0_dp,1.0_dp,0.0_dp/),(/3,3/))
+             else ! Default to Triclinic (same behavior as VASP)
+                id = 44
+                s_range = 1
+                O = U
              end if
           else
              if (isclose((A/2.0_dp),E,atol_=eps) .and. isclose((2.0_dp*D),F,atol_=eps)) then


### PR DESCRIPTION
For some fcc, and bcc enumerated structures the kpoints.x routine fails to generate because no Niggli cell id is recognized. After thorough testing of the 1-10 atom cases, I identified over 3,000 cases where this happens. In every case the Niggli id routine ends up in the modified if statement and exits. The OUTCAR for each case chooses the lattice symmetry LATTYP: triclinic. To achieve the same results I have added a default to triclinic else statement.